### PR TITLE
Allow overriding container images

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ The pods that the operator consist of two containers. One is the openscap
 container itself at [https://github.com/jhrozek/openscap-ocp](jhrozek/openscap-ocp)
 and the other is a log-collector at [https://github.com/jhrozek/scapresults-k8s](jhrozek/scapresults-k8s)
 
+### Overriding container images
+Should you wish to override any of the two container images in the pod, you can
+do so using environment variables:
+    * `OPENSCAP_IMAGE` for the scanner container
+    * `LOG_COLLECTOR_IMAGE` for the log collecting container
+
+For example, to run the log collector from a different branch:
+```
+make run LOG_COLLECTOR_IMAGE=quay.io/jhrozek/scapresults-k8s:testbranch
+```
 
 ## TODO
 - using a configMap for reporting is not very nice using a volume would be nicer

--- a/pkg/controller/compliancescan/compliancescan_controller.go
+++ b/pkg/controller/compliancescan/compliancescan_controller.go
@@ -283,7 +283,7 @@ func newPodForNode(openScapCr *complianceoperatorv1alpha1.ComplianceScan, node *
 			Containers: []corev1.Container{
 				{
 					Name:  "log-collector",
-					Image: "quay.io/jhrozek/scapresults-k8s:latest",
+					Image: GetComponentImage(LOG_COLLECTOR),
 					Args: []string{
 						"--file=/reports/report.xml",
 						"--config-map-name=" + podName,
@@ -302,7 +302,7 @@ func newPodForNode(openScapCr *complianceoperatorv1alpha1.ComplianceScan, node *
 				},
 				{
 					Name:  "openscap-ocp",
-					Image: "quay.io/jhrozek/openscap-ocp:latest",
+					Image: GetComponentImage(OPENSCAP),
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &trueVal,
 					},

--- a/pkg/controller/compliancescan/utils.go
+++ b/pkg/controller/compliancescan/utils.go
@@ -1,0 +1,32 @@
+package compliancescan
+
+import (
+	"os"
+)
+
+type ComplianceComponent uint
+
+const (
+	LOG_COLLECTOR = iota
+	OPENSCAP
+)
+
+var componentDefaults = []struct {
+	defaultImage string
+	envVar       string
+}{
+	{"quay.io/jhrozek/scapresults-k8s:latest", "LOG_COLLECTOR_IMAGE"},
+	{"quay.io/jhrozek/openscap-ocp:latest", "OPENSCAP_IMAGE"},
+}
+
+// GetComponentImage returns a full image pull spec for a given component
+// based on the component type
+func GetComponentImage(component ComplianceComponent) string {
+	comp := componentDefaults[component]
+
+	imageTag := os.Getenv(comp.envVar)
+	if imageTag == "" {
+		imageTag = comp.defaultImage
+	}
+	return imageTag
+}


### PR DESCRIPTION
To make development more user-friedly, let's allow overriding container images like this:
    make run LOG_COLLECTOR_IMAGE=quay.io/jhrozek/scapresults-k8s:testbranch