### PR TITLE
Change namespace from "compliance" to "openshift-compliance"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export APP_NAME=compliance-operator
 APP_REPO=github.com/jhrozek/$(APP_NAME)
 TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
 MAIN_PKG=cmd/manager/main.go
-export NAMESPACE?=compliance
+export NAMESPACE?=openshift-compliance
 
 PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
 
@@ -50,7 +50,7 @@ build: fmt
 
 run:
 	OPERATOR_NAME=compliance-operator \
-	WATCH_NAMESPACE=compliance \
+	WATCH_NAMESPACE=$(NAMESPACE) \
 	KUBERNETES_CONFIG=$(KUBECONFIG) \
 	$(GO) run ${MAIN_PKG}
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the operator from the command line instead, delete the deployment and then
 run:
 
 ```
-OPERATOR_NAME=compliance-scan operator-sdk up local --namespace "compliance"
+OPERATOR_NAME=compliance-scan operator-sdk up local --namespace "openshift-compliance"
 ```
 
 At this point the operator would pick up the CRD, create a pod for every
@@ -70,7 +70,7 @@ A more convenient way to fetch the results is using
 To use the script, clone the [scapresults-k8s repo](jhrozek/scapresults-k8s),
 then run the `scapresults/fetchresults.py` script:
 ```
-$ python3 scapresults/fetchresults.py --owner=example-openscap --namespace=compliance --dir=/tmp/results
+$ python3 scapresults/fetchresults.py --owner=example-openscap --namespace=openshift-compliance --dir=/tmp/results
 ```
 The parameters you need to supply is the name of the scan CRD through the
 `--owner` CLI flag and the namespace. The output directory is optional and

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: read-secrets-global
 subjects:
 - kind: ServiceAccount
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
 roleRef:
   kind: ClusterRole

--- a/deploy/ns.yaml
+++ b/deploy/ns.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-      name: compliance
+      name: openshift-compliance

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: compliance-operator
-  namespace: compliance
+  namespace: openshift-compliance
 spec:
   replicas: 1
   selector:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
 rules:
 - apiGroups:
@@ -54,7 +54,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: scc-priv
-  namespace: compliance
+  namespace: openshift-compliance
 rules:
   - apiGroups:
       - security.openshift.io

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,29 +1,29 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
 subjects:
 - kind: ServiceAccount
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
 roleRef:
   kind: Role
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator-scc-priv
 subjects:
 - kind: ServiceAccount
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator
 roleRef:
   kind: Role
-  namespace: compliance
+  namespace: openshift-compliance
   name: scc-priv
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: compliance
+  namespace: openshift-compliance
   name: compliance-operator

--- a/go.mod
+++ b/go.mod
@@ -32,3 +32,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.10.0
+
+go 1.13


### PR DESCRIPTION
Even though this operator is not really tied to openshift itself, havin
the "openshift-" prefix in the namespace ensures that the stdout logs
coming from this operator and its pods are taken as infrastructure
resources. And thus proper log forwarding is ensured.